### PR TITLE
Fix import path for eris

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 
 replace github.com/zserge/lorca => github.com/eyedeekay/lorca v0.1.9-0.20200403221704-ea2ffcadfc1b
 
-replace github.com/prologic/eris => github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7
+replace git.mills.io/prologic/eris => git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7
 
 replace github.com/eyedeekay/zerobundle => ./zerobundle
 

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7 h1:msmkJRmgaNlFlKosza41CWNPkYwQyOwRcIpWA5gFrQ4=
-github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7/go.mod h1:4y/W8p1NQTA7UR5mH2HDSFxBvuY0N/VSVj2mokpt2sQ=
+git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7 h1:msmkJRmgaNlFlKosza41CWNPkYwQyOwRcIpWA5gFrQ4=
+git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7/go.mod h1:4y/W8p1NQTA7UR5mH2HDSFxBvuY0N/VSVj2mokpt2sQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/eris](https://git.mills.io/prologic/eris).

For details on why see: https://github.com/prologic

Thank you! 🙇